### PR TITLE
Add required_ruby_version to gemspec

### DIFF
--- a/lottery_box.gemspec
+++ b/lottery_box.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
+  spec.required_ruby_version = '>= 2.0.0'
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
1.9系ではsyntaxエラーになるので追加しました
